### PR TITLE
Dropdown übersichtlicher

### DIFF
--- a/assets/quicknavi.css
+++ b/assets/quicknavi.css
@@ -23,4 +23,9 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	padding-top: 6px;
+	padding-bottom: 10px;
+}
+.quicknavi li small {
+	display: block;
 }

--- a/lib/QuickNavigation.php
+++ b/lib/QuickNavigation.php
@@ -58,7 +58,7 @@ class QuickNavigation
                             ]
                         )
                     ];
-                    $link .= '<li><a ' . rex_string::buildAttributes($attributes) . ' title="' . $data['name'] . '">' . $data['name'] . '<br /><small>' . $langcode . '<i class="fa fa-user" aria-hidden="true"></i> ' . $data['updateuser'] . ' - ' . $date . '</small></a></li>';
+                    $link .= '<li><a ' . rex_string::buildAttributes($attributes) . ' title="' . $data['name'] . '">' . $data['name'] . '<small>' . $langcode . '<i class="fa fa-user" aria-hidden="true"></i> ' . $data['updateuser'] . ' - ' . $date . '</small></a></li>';
                 }
             }
 


### PR DESCRIPTION
Zwischen den einzelnen Einträgen ist etwas mehr Luft, dafür habe ich die Metazeile nächer an den Artikelnamen gerückt. Ist imho übersichtlicher und sieht besser aus.
![quicknavi](https://cloud.githubusercontent.com/assets/7223820/22858425/3481ed70-f0bd-11e6-869f-aaa83304c9c9.png)
