### PR TITLE
Kompatibilität zu R5.6

### DIFF
--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -36,16 +36,14 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
                     if ($langcode) {
                         $langcode = '<i class="fa fa-flag-o" aria-hidden="true"></i> ' . $langcode . ' - ';
                     }
-                   $date = rex_formatter::strftime(strtotime($data['updatedate']), 'datetime');
-                   $attributes = [
-                        'href' => rex_url::backendPage('content/edit',
+                    $date = rex_formatter::strftime(strtotime($data['updatedate']), 'datetime');
+                    $href = rex_url::backendPage('content/edit',
                             [
                                 'mode' => 'edit',
                                 'clang' => $data['clang_id'],
                                 'article_id' => $data['id']
                             ]
-                        )
-                    ];
+                        );
 
 					
 			if(rex_addon::get('yrewrite')->isAvailable()) {
@@ -56,8 +54,8 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
 
 				}
 					$name = rex_escape($data['name']);
-                    $link .= '<li class=""><a class="quicknavi_left" ' . rex_string::buildAttributes($attributes) . ' title="' . $name . '">' . $name . '<small>' . $langcode . '<i class="fa fa-user" aria-hidden="true"></i> ' . rex_escape($data['updateuser']) . ' - ' . $date . $domaintitle . '</small></a><span class="quicknavi_right"><a href="'.rex_getUrl($dataID).'" title="'.  $name . ' '. $this->i18n("title_eye") .'" target="blank"><i class="fa fa-eye" aria-hidden="true"></i></a></span></li>';
                 	
+                    $link .= '<li class=""><a class="quicknavi_left" href="' . $href . '" title="' . $name . '">' . $name . '<small>' . $langcode . '<i class="fa fa-user" aria-hidden="true"></i> ' . rex_escape($data['updateuser']) . ' - ' . $date . $domaintitle . '</small></a><span class="quicknavi_right"><a href="'.rex_getUrl($dataID).'" title="'.  $name . ' '. $this->i18n("title_eye") .'" target="blank"><i class="fa fa-eye" aria-hidden="true"></i></a></span></li>';
                 }
                 
             }

--- a/fragments/quick_favs.php
+++ b/fragments/quick_favs.php
@@ -19,25 +19,21 @@ if (count($datas)) {
 				   $cat = rex_category::get($data);
 				   $catName = rex_escape($cat->getName());
 				   $catId = rex_escape($cat->getId());
-				   $attributes = [
-						'href' => rex_url::backendPage('content/edit',
-							[
-								'page' => 'structure',
-								'clang' => $this->clang,
-								'category_id' => $data
-							]
-						)
-					];
-                    $addAttributes = [
-                        'href' => rex_url::backendPage('structure',
+				   $href = rex_url::backendPage('content/edit',
+                            [
+                                'page' => 'structure',
+                                'clang' => $this->clang,
+                                'category_id' => $data
+                            ]
+                        );
+                    $addHref = rex_url::backendPage('structure',
                             [
                                 'category_id' => $catId,
                                 'clang' => $this->clang,
                                 'function' => 'add_art'
                             ]
-                        )
-                    ];
-					$link .= '<li class="quicknavi_left"><a ' . rex_string::buildAttributes($attributes) . ' title="' . $catName . '">' . $catName .'</a></li><li class="quicknavi_right"><a ' . rex_string::buildAttributes($addAttributes) . ' title="'. $this->i18n("title_favs") .' '.  $catName . '"><i class="fa fa-plus" aria-hidden="true"></i></a></li>';
+                        );
+					$link .= '<li class="quicknavi_left"><a href="' . $href . '" title="' . $catName . '">' . $catName .'</a></li><li class="quicknavi_right"><a href="' . $addHref . '" title="'. $this->i18n("title_favs") .' '.  $catName . '"><i class="fa fa-plus" aria-hidden="true"></i></a></li>';
 			   }
 			}	   
             

--- a/fragments/quick_media.php
+++ b/fragments/quick_media.php
@@ -35,24 +35,22 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
                     $entryname = '';
                    
                    $date = rex_formatter::strftime(strtotime($data['updatedate']), 'datetime');
-                   $attributes = [
-                        'href' => rex_url::backendPage('mediapool/media',
+                   $href = rex_url::backendPage('mediapool/media',
                             [
                                 'opener_input_field'=> $opener,
                                 'rex_file_category' => $data['category_id'],
                                 'file_id' => $data['id']
                             ]
-                        )
-                    ];
-                    
+                        );
+
                     if ($data['title']!='')
 					{ $entryname =   rex_escape($data['title']); }  
 					else {
 						 $entryname = rex_escape($data['filename']);
 					}  
 					$filename = rex_escape($data['filename']);
-                    
-                    $link .= '<li><a ' . rex_string::buildAttributes($attributes) . ' title="' . $filename . '">' . $entryname. '<small> <i class="fa fa-user" aria-hidden="true"></i> ' . rex_escape($data['updateuser']) . ' - ' . $date . '</small></a></li>';
+
+                    $link .= '<li><a href="' . $href . '" title="' . $filename . '">' . $entryname. '<small> <i class="fa fa-user" aria-hidden="true"></i> ' . rex_escape($data['updateuser']) . ' - ' . $date . '</small></a></li>';
                 }
             }
 ?>

--- a/fragments/quick_sked.php
+++ b/fragments/quick_sked.php
@@ -41,35 +41,31 @@ if (count($skeds)) {
 		    		
 		    		$sked_color 			= rex_escape($sked_entry->category_color);
 
-		    		
-			    	$attributes = [
-								'href' => rex_url::backendPage('sked/entries',
-									[
-										'func' => 'edit',
-										'id' => $skedId
-									]
-								)
-							];
-					
 
-		
-					$link .= '<li class="sked_border" style="border-color:'.$sked_color.'"><a ' . rex_string::buildAttributes($attributes) . ' title="' . $sked_name  . '">' . $sked_name .'<small>' . $sked_start_date . ' bis ' . $sked_end_date . ' - ' . $sked_start_time . ' bis ' . $sked_end_time .'</small></a></li>';
-		
+			    	$href = rex_url::backendPage('sked/entries',
+                            [
+                                'func' => 'edit',
+                                'id' => $skedId
+                            ]
+                        );
+
+
+
+					$link .= '<li class="sked_border" style="border-color:'.$sked_color.'"><a href="' . $href . '" title="' . $sked_name  . '">' . $sked_name .'<small>' . $sked_start_date . ' bis ' . $sked_end_date . ' - ' . $sked_start_time . ' bis ' . $sked_end_time .'</small></a></li>';
+
 				}
 			//		$addLink .= '<li class="quicknavi_right"><a type="button" class="btn btn-default' . rex_string::buildAttributes($addAtrributes) . ' title="'. $this->i18n("sked_add_new_entry") .'"><i class="fa fa-plus" aria-hidden="true"></i></a></li><li class="quicknavi_left"><a ' . rex_string::buildAttributes($addAtrributes) . ' title="'. $this->i18n("sked_add_new_entry") .'">'.$this->i18n("sked_add_new_entry").'</a>';
 ?>
 		   
 <?php  
 }
-					$addAtrributes = [
-								'href' => rex_url::backendPage('sked/entries',
-									[
-										'func' => 'add'
-									]
-								)
-							];
-					$addLink .= '<li class=""><a class="btn btn-default" ' . rex_string::buildAttributes($addAtrributes) . ' title="'. $this->i18n("sked_add_new_entry") .'"><i class="fa fa-plus" aria-hidden="true"> &nbsp&nbsp'.$this->i18n("sked_add_new_entry").'</i></a></li>';
-		
+					$href = rex_url::backendPage('sked/entries',
+                            [
+                                'func' => 'add'
+                            ]
+                        );
+					$addLink .= '<li class=""><a class="btn btn-default" href="' . $href . '" title="'. $this->i18n("sked_add_new_entry") .'"><i class="fa fa-plus" aria-hidden="true"> &nbsp&nbsp'.$this->i18n("sked_add_new_entry").'</i></a></li>';
+
 
 ?>
              <div class="btn-group">

--- a/fragments/quick_yform.php
+++ b/fragments/quick_yform.php
@@ -20,24 +20,20 @@ if (count($tables)) {
 	    	$table_name = rex_escape($table->getTableName());
 	    	$table_real_name = rex_escape(rex_i18n::translate($table->getName()));
 	    	$table_id = rex_escape($table->getId());
-	    	$attributes = [
-						'href' => rex_url::backendPage('yform/manager/data_edit',
-							[
-								'page' => 'yform/manager/data_edit',
-								'table_name' => $table_name
-							]
-						)
-					];
-			$addAtrributes = [
-						'href' => rex_url::backendPage('yform/manager/data_edit',
-							[
-								'page' => 'yform/manager/data_edit',
-								'table_name' => $table_name,
-								'func' => 'add'
-							]
-						)
-					];
-			$link .= '<li class="quicknavi_left"><a ' . rex_string::buildAttributes($attributes) . ' title="' . $table_name . '">' . $table_real_name .'</a></li><li class="quicknavi_right"><a ' . rex_string::buildAttributes($addAtrributes) . ' title="'. $this->i18n("title_yform") .' '.  $table_name . '"><i class="fa fa-plus" aria-hidden="true"></i></a></li>';
+	    	$href = rex_url::backendPage('yform/manager/data_edit',
+                        [
+                            'page' => 'yform/manager/data_edit',
+                            'table_name' => $table_name
+                        ]
+                    );
+			$addHref = rex_url::backendPage('yform/manager/data_edit',
+                        [
+                            'page' => 'yform/manager/data_edit',
+                            'table_name' => $table_name,
+                            'func' => 'add'
+                        ]
+                    );
+			$link .= '<li class="quicknavi_left"><a href="' . $href . '" title="' . $table_name . '">' . $table_real_name .'</a></li><li class="quicknavi_right"><a href="' . $addHref . '" title="'. $this->i18n("title_yform") .' '.  $table_name . '"><i class="fa fa-plus" aria-hidden="true"></i></a></li>';
 			$addLink .= '';
 
 		}


### PR DESCRIPTION
Siehe https://github.com/redaxo/redaxo/pull/1687#issuecomment-389761965

Um jetzt nicht für R<5.6 das implizite Escaping drin zu lassen, und für R>=5.6 nicht, habe ich `buildAttributes` ganz entfernt, da ja sowieso immer nur ein Attribute (`href`) gesetzt wurde.

/cc @staabm 