### PR TITLE
Artikel blättern

### DIFF
--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -89,23 +89,18 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
         $current_id = rex_request('article_id');
         $page = rex_request('page');
            if ( $page != "structure"  && $cat && $current_id && $current_id != 0){
-            // alle Artikel aus der aktuellen Kategorie laden
-            $article = $cat->getArticles(true);
+            $article = $cat->getArticles(false);
             if (is_array($article)) {
                 // Artikelreihenfolge in eine Array schreiben
                 foreach ($article as $var) {
-                    // Startartikel werden ignoriert
-
                     $article_stack[] = $var->getId();
                 }
-
                 $i = 0;
                 // Zahl der Artikel ermitteln
                 $catcount = count($article_stack);
                 foreach ($article_stack as $var) {
                     if ($var == $current_id) {
                         $successor = '
-
                         <button class="btn btn-default" disabled>
                            <span class="fa fa-chevron-right"> 
                         </button>
@@ -113,7 +108,6 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
                         if ($i+1 < $catcount) {
                             // ID des nachfolgenden Artikels ermitteln
                             $next_id = $article_stack[$i+1];
-
                             // Artikel-Objekt holen, um den Namen des vorhergehenden Artikels zu ermitteln,
                             // danach Link schreiben
                             $article = rex_article::get($next_id);

--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -87,8 +87,121 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
 	}
 
         if ($mode !='minibar') {
-        ?>    
-		<div class="btn-group">
+        $predecessor = '';
+$successor = '';
+$article_stack[] = array();
+
+// Objekt der aktuellen Kategorie laden
+$cat = rex_category::get(rex_request('category_id'));
+
+// aktuellen Artikel ermitteln
+$current_id = rex_request('article_id');
+$current_article = rex_article::get($current_id);
+
+// alle Artikel aus der aktuellen Kategorie laden
+$article = $cat->getArticles(true);
+
+if (is_array($article)) {
+    // Artikelreihenfolge in eine Array schreiben
+    foreach ($article as $var) {  
+        // Startartikel werden ignoriert
+
+        $article_stack[] = $var->getId();
+    }
+
+    $i = 0;
+    // Zahl der Artikel ermitteln
+    $catcount = count($article_stack);
+    foreach ($article_stack as $var) { 
+        if($var == $current_id) {
+              $successor = '
+
+                        <button class="btn btn-default" disabled>
+                           <span class="fa fa-chevron-right"> 
+                        </button>
+                    ';
+            if($i+1 < $catcount ) {
+                // ID des nachfolgenden Artikels ermitteln
+                $next_id = $article_stack[$i+1];
+
+                // Artikel-Objekt holen, um den Namen des vorhergehenden Artikels zu ermitteln,
+                // danach Link schreiben
+                $article = rex_article::get($next_id);
+                
+                $href_next = rex_url::backendPage(
+					'content/edit',
+					[
+					'mode' => 'edit',
+					'clang' => $data['clang_id'],
+                    'category_id' => rex_request('category_id'),
+					'article_id' => $next_id
+				]
+				);
+
+
+
+
+                $successor = '
+
+                    <a class="btn btn-default" href="'.$href_next.'">
+                      <span class="fa fa-chevron-right"> 
+                    </a>
+                ';
+
+
+
+
+            }
+
+            // und das Ganze nochmal für den vorhergehenden Artikel
+            if($i-1 > -1) {
+                $prev_id = $article_stack[$i-1];   
+                
+                  $href_prev = rex_url::backendPage(
+					'content/edit',
+					[
+					'mode' => 'edit',
+					'clang' => $data['clang_id'],
+                    'category_id' => rex_request('category_id'),
+					'article_id' => $prev_id
+				]
+				);
+
+                if($i < $catcount ) {
+
+                    $article = rex_article::get($prev_id);
+
+
+                    $predecessor = '
+
+                        <button class="btn btn-default" disabled>
+                           <span class="fa fa-chevron-left"> 
+                        </button>
+                    ';
+
+                   if ($article){
+                  $predecessor = '
+
+                        <a class="btn btn-default" href="'.$href_prev.'">
+                           <span class="fa fa-chevron-left"> 
+                        </a>
+                    ';
+                }
+                    }
+
+            }
+        }  
+        $i++;
+    }
+}
+$vz = '
+
+    '.$predecessor.'
+
+    '.$successor.'
+';
+?>   
+		<div class="btn-group"><?= $vz ?>
 		<button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
 		<i class="fa fa-clock-o" aria-hidden="true"></i>
 		<span class="caret"></span>
@@ -102,4 +215,6 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
 		<?= $link ?>
 		</ul>
 <?php } }
+
+
 

--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -83,16 +83,12 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
         $predecessor = '';
         $successor = '';
         $article_stack[] = array();
-
         // Objekt der aktuellen Kategorie laden
-        $cat = rex_category::get(rex_request('category_id'));
-        if ($cat) {
-            // aktuellen Artikel ermitteln
-            $current_id = rex_request('article_id');
-
+        $cat = rex_category::getCurrent();
+        $current_id = rex_request('article_id');
+        if ($cat && $current_id && $current_id != 0) {
             // alle Artikel aus der aktuellen Kategorie laden
             $article = $cat->getArticles(true);
-
             if (is_array($article)) {
                 // Artikelreihenfolge in eine Array schreiben
                 foreach ($article as $var) {
@@ -129,10 +125,6 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
                     'article_id' => $next_id
                 ]
                             );
-
-
-
-
                             $successor = '
 
                     <a class="btn btn-default" href="'.$href_next.'">

--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -60,6 +60,7 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
                     [
                     'mode' => 'edit',
                     'clang' => $data['clang_id'],
+	            'category_id' => $data['parent_id'],
                     'article_id' => $data['id']
                 ]
                 );

--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -129,7 +129,7 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
                             );
                             $successor = '
 
-                    <a class="btn btn-default" href="'.$href_next.'">
+                    <a class="btn btn-default" title="'.$article->getName().'" href="'.$href_next.'">
                       <span class="fa fa-chevron-right"> 
                     </a>
                 ';
@@ -163,7 +163,7 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
                                 if ($article) {
                                     $predecessor = '
 
-                        <a class="btn btn-default" href="'.$href_prev.'">
+                        <a class="btn btn-default" title="'.$article->getName().'" href="'.$href_prev.'">
                            <span class="fa fa-chevron-left"> 
                         </a>
                     ';
@@ -196,3 +196,4 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
 		</ul>
 <?php }
 }
+

--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -86,106 +86,107 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
 
         // Objekt der aktuellen Kategorie laden
         $cat = rex_category::get(rex_request('category_id'));
+        if ($cat) {
+            // aktuellen Artikel ermitteln
+            $current_id = rex_request('article_id');
 
-        // aktuellen Artikel ermitteln
-        $current_id = rex_request('article_id');
+            // alle Artikel aus der aktuellen Kategorie laden
+            $article = $cat->getArticles(true);
 
-        // alle Artikel aus der aktuellen Kategorie laden
-        $article = $cat->getArticles(true);
+            if (is_array($article)) {
+                // Artikelreihenfolge in eine Array schreiben
+                foreach ($article as $var) {
+                    // Startartikel werden ignoriert
 
-        if (is_array($article)) {
-            // Artikelreihenfolge in eine Array schreiben
-            foreach ($article as $var) {
-                // Startartikel werden ignoriert
+                    $article_stack[] = $var->getId();
+                }
 
-                $article_stack[] = $var->getId();
-            }
-
-            $i = 0;
-            // Zahl der Artikel ermitteln
-            $catcount = count($article_stack);
-            foreach ($article_stack as $var) {
-                if ($var == $current_id) {
-                    $successor = '
+                $i = 0;
+                // Zahl der Artikel ermitteln
+                $catcount = count($article_stack);
+                foreach ($article_stack as $var) {
+                    if ($var == $current_id) {
+                        $successor = '
 
                         <button class="btn btn-default" disabled>
                            <span class="fa fa-chevron-right"> 
                         </button>
                     ';
-                    if ($i+1 < $catcount) {
-                        // ID des nachfolgenden Artikels ermitteln
-                        $next_id = $article_stack[$i+1];
+                        if ($i+1 < $catcount) {
+                            // ID des nachfolgenden Artikels ermitteln
+                            $next_id = $article_stack[$i+1];
 
-                        // Artikel-Objekt holen, um den Namen des vorhergehenden Artikels zu ermitteln,
-                        // danach Link schreiben
-                        $article = rex_article::get($next_id);
+                            // Artikel-Objekt holen, um den Namen des vorhergehenden Artikels zu ermitteln,
+                            // danach Link schreiben
+                            $article = rex_article::get($next_id);
                 
-                        $href_next = rex_url::backendPage(
-                            'content/edit',
-                            [
+                            $href_next = rex_url::backendPage(
+                                'content/edit',
+                                [
                     'mode' => 'edit',
                     'clang' => $data['clang_id'],
                     'category_id' => rex_request('category_id'),
                     'article_id' => $next_id
                 ]
-                        );
+                            );
 
 
 
 
-                        $successor = '
+                            $successor = '
 
                     <a class="btn btn-default" href="'.$href_next.'">
                       <span class="fa fa-chevron-right"> 
                     </a>
                 ';
-                    }
+                        }
 
-                    // und das Ganze nochmal für den vorhergehenden Artikel
-                    if ($i-1 > -1) {
-                        $prev_id = $article_stack[$i-1];
+                        // und das Ganze nochmal für den vorhergehenden Artikel
+                        if ($i-1 > -1) {
+                            $prev_id = $article_stack[$i-1];
                 
-                        $href_prev = rex_url::backendPage(
-                            'content/edit',
-                            [
+                            $href_prev = rex_url::backendPage(
+                                'content/edit',
+                                [
                     'mode' => 'edit',
                     'clang' => $data['clang_id'],
                     'category_id' => rex_request('category_id'),
                     'article_id' => $prev_id
                 ]
-                        );
+                            );
 
-                        if ($i < $catcount) {
-                            $article = rex_article::get($prev_id);
+                            if ($i < $catcount) {
+                                $article = rex_article::get($prev_id);
 
 
-                            $predecessor = '
+                                $predecessor = '
 
                         <button class="btn btn-default" disabled>
                            <span class="fa fa-chevron-left"> 
                         </button>
                     ';
 
-                            if ($article) {
-                                $predecessor = '
+                                if ($article) {
+                                    $predecessor = '
 
                         <a class="btn btn-default" href="'.$href_prev.'">
                            <span class="fa fa-chevron-left"> 
                         </a>
                     ';
+                                }
                             }
                         }
                     }
+                    $i++;
                 }
-                $i++;
             }
-        }
-        $vz = '
+            $vz = '
 
     '.$predecessor.'
 
     '.$successor.'
-'; ?>   
+';
+        } ?>   
 		<div class="btn-group"><?= $vz ?>
 		<button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
 		<i class="fa fa-clock-o" aria-hidden="true"></i>
@@ -201,4 +202,3 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
 		</ul>
 <?php }
 }
-

--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -86,7 +86,8 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
         // Objekt der aktuellen Kategorie laden
         $cat = rex_category::getCurrent();
         $current_id = rex_request('article_id');
-        if ($cat && $current_id && $current_id != 0) {
+        $page = rex_request('page');
+           if ( $page != "structure"  && $cat && $current_id && $current_id != 0){
             // alle Artikel aus der aktuellen Kategorie laden
             $article = $cat->getArticles(true);
             if (is_array($article)) {

--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -1,5 +1,5 @@
 <?php
-	/**
+    /**
  * This file is part of the Quick Navigation package.
  *
  * @author (c) Friends Of REDAXO
@@ -11,196 +11,178 @@
 
 $drophistory = $date = $name = $mode = $link = $where = $domaintitle = $status_css = '';
 
-if (!isset($this->mode))
-    {
+if (!isset($this->mode)) {
     $mode ='structure';
-}
-else
-{
+} else {
     $mode = $this->mode;
 }
 
 
 if ($mode =='minibar') {
-
     $icon_prefix ='rex-minibar-icon--fa rex-minibar-icon--';
-
-   }
-else {
-     $icon_prefix ='fa ';
+} else {
+    $icon_prefix ='fa ';
 }
 
 if (rex::getUser()->hasPerm('quick_navigation[history]')) {
-	$were ='';
-	if (!rex::getUser()->hasPerm('quick_navigation[all_changes]')) {
-		$where = 'WHERE updateuser="'.rex::getUser()->getValue('login').'"';
-	}
+    $were ='';
+    if (!rex::getUser()->hasPerm('quick_navigation[all_changes]')) {
+        $where = 'WHERE updateuser="'.rex::getUser()->getValue('login').'"';
+    }
 
-	$qry = 'SELECT id, status, parent_id, clang_id, startarticle, name, updateuser, updatedate
+    $qry = 'SELECT id, status, parent_id, clang_id, startarticle, name, updateuser, updatedate
                     FROM ' . rex::getTable('article') . ' 
                     '. $where .' 
                     ORDER BY updatedate DESC
                     LIMIT '.$this->limit;
-	$datas = rex_sql::factory()->getArray($qry);
+    $datas = rex_sql::factory()->getArray($qry);
 
-	if (!count($datas)) {
-		$link .= '<li class="alert">'.rex_i18n::msg('quick_navigation_no_entries').'</li>';
-	}
-
-	if (count($datas)) {
-		foreach ($datas as $data) {
-			$dataID = rex_escape($data['id']);
-			$lang = rex_clang::get($data['clang_id']);
-			$langcode = $lang->getCode();
-			if ($langcode) {
-				$langcode = '<i class="fa fa-flag-o" aria-hidden="true"></i> ' . $langcode . ' - ';
-			}
-			$name = rex_escape($data['name']);
-			$date = rex_formatter::strftime(strtotime($data['updatedate']), 'datetime');
-
-			if ($mode =='linkmap') {
-				$href = "javascript:insertLink('redaxo://".$dataID."','".$name." [".$dataID."]');";
-			} 
-			else {
-				$href = rex_url::backendPage(
-					'content/edit',
-					[
-					'mode' => 'edit',
-					'clang' => $data['clang_id'],
-					'article_id' => $data['id']
-				]
-				);
-			}
-
-			if (rex_addon::get('yrewrite')->isAvailable()) {
-				if (count(rex_yrewrite::getDomains())>2) {
-					$domain = rex_yrewrite::getDomainByArticleId($data['id']);
-					if ($domain) {
-					        $domaintitle = '<br><i class="fa fa-globe" aria-hidden="true"></i> '.rex_escape($domain);
-					}
-				}
-			}
-                        $status_css = ' qn_status_'.$data['status'];
-			$link .= '<li class=""><a class="quicknavi_left '. $status_css .'" href="' . $href . '" title="' . $name . '">' . $name . '<small>' . $langcode . '<i class="'. $icon_prefix.'fa-user" aria-hidden="true"></i> ' . rex_escape($data['updateuser']) . ' - ' . $date . $domaintitle . '</small></a>';
-			$link .= '<span class="quicknavi_right"><a class ="'. $status_css .'" href="'.rex_getUrl($dataID).'" title="'.  $name . ' '. $this->i18n("title_eye") .'" target="blank"><i class="'. $icon_prefix.'fa-eye" aria-hidden="true"></i></a></span></li>';
-		}
-	}
-
-        if ($mode !='minibar') {
-        $predecessor = '';
-$successor = '';
-$article_stack[] = array();
-
-// Objekt der aktuellen Kategorie laden
-$cat = rex_category::get(rex_request('category_id'));
-
-// aktuellen Artikel ermitteln
-$current_id = rex_request('article_id');
-$current_article = rex_article::get($current_id);
-
-// alle Artikel aus der aktuellen Kategorie laden
-$article = $cat->getArticles(true);
-
-if (is_array($article)) {
-    // Artikelreihenfolge in eine Array schreiben
-    foreach ($article as $var) {  
-        // Startartikel werden ignoriert
-
-        $article_stack[] = $var->getId();
+    if (!count($datas)) {
+        $link .= '<li class="alert">'.rex_i18n::msg('quick_navigation_no_entries').'</li>';
     }
 
-    $i = 0;
-    // Zahl der Artikel ermitteln
-    $catcount = count($article_stack);
-    foreach ($article_stack as $var) { 
-        if($var == $current_id) {
-              $successor = '
+    if (count($datas)) {
+        foreach ($datas as $data) {
+            $dataID = rex_escape($data['id']);
+            $lang = rex_clang::get($data['clang_id']);
+            $langcode = $lang->getCode();
+            if ($langcode) {
+                $langcode = '<i class="fa fa-flag-o" aria-hidden="true"></i> ' . $langcode . ' - ';
+            }
+            $name = rex_escape($data['name']);
+            $date = rex_formatter::strftime(strtotime($data['updatedate']), 'datetime');
+
+            if ($mode =='linkmap') {
+                $href = "javascript:insertLink('redaxo://".$dataID."','".$name." [".$dataID."]');";
+            } else {
+                $href = rex_url::backendPage(
+                    'content/edit',
+                    [
+                    'mode' => 'edit',
+                    'clang' => $data['clang_id'],
+                    'article_id' => $data['id']
+                ]
+                );
+            }
+
+            if (rex_addon::get('yrewrite')->isAvailable()) {
+                if (count(rex_yrewrite::getDomains())>2) {
+                    $domain = rex_yrewrite::getDomainByArticleId($data['id']);
+                    if ($domain) {
+                        $domaintitle = '<br><i class="fa fa-globe" aria-hidden="true"></i> '.rex_escape($domain);
+                    }
+                }
+            }
+            $status_css = ' qn_status_'.$data['status'];
+            $link .= '<li class=""><a class="quicknavi_left '. $status_css .'" href="' . $href . '" title="' . $name . '">' . $name . '<small>' . $langcode . '<i class="'. $icon_prefix.'fa-user" aria-hidden="true"></i> ' . rex_escape($data['updateuser']) . ' - ' . $date . $domaintitle . '</small></a>';
+            $link .= '<span class="quicknavi_right"><a class ="'. $status_css .'" href="'.rex_getUrl($dataID).'" title="'.  $name . ' '. $this->i18n("title_eye") .'" target="blank"><i class="'. $icon_prefix.'fa-eye" aria-hidden="true"></i></a></span></li>';
+        }
+    }
+
+    if ($mode !='minibar') {
+        $predecessor = '';
+        $successor = '';
+        $article_stack[] = array();
+
+        // Objekt der aktuellen Kategorie laden
+        $cat = rex_category::get(rex_request('category_id'));
+
+        // alle Artikel aus der aktuellen Kategorie laden
+        $article = $cat->getArticles(true);
+
+        if (is_array($article)) {
+            // Artikelreihenfolge in eine Array schreiben
+            foreach ($article as $var) {
+                // Startartikel werden ignoriert
+
+                $article_stack[] = $var->getId();
+            }
+
+            $i = 0;
+            // Zahl der Artikel ermitteln
+            $catcount = count($article_stack);
+            foreach ($article_stack as $var) {
+                if ($var == $current_id) {
+                    $successor = '
 
                         <button class="btn btn-default" disabled>
                            <span class="fa fa-chevron-right"> 
                         </button>
                     ';
-            if($i+1 < $catcount ) {
-                // ID des nachfolgenden Artikels ermitteln
-                $next_id = $article_stack[$i+1];
+                    if ($i+1 < $catcount) {
+                        // ID des nachfolgenden Artikels ermitteln
+                        $next_id = $article_stack[$i+1];
 
-                // Artikel-Objekt holen, um den Namen des vorhergehenden Artikels zu ermitteln,
-                // danach Link schreiben
-                $article = rex_article::get($next_id);
+                        // Artikel-Objekt holen, um den Namen des vorhergehenden Artikels zu ermitteln,
+                        // danach Link schreiben
+                        $article = rex_article::get($next_id);
                 
-                $href_next = rex_url::backendPage(
-					'content/edit',
-					[
-					'mode' => 'edit',
-					'clang' => $data['clang_id'],
+                        $href_next = rex_url::backendPage(
+                            'content/edit',
+                            [
+                    'mode' => 'edit',
+                    'clang' => $data['clang_id'],
                     'category_id' => rex_request('category_id'),
-					'article_id' => $next_id
-				]
-				);
+                    'article_id' => $next_id
+                ]
+                        );
 
 
 
 
-                $successor = '
+                        $successor = '
 
                     <a class="btn btn-default" href="'.$href_next.'">
                       <span class="fa fa-chevron-right"> 
                     </a>
                 ';
+                    }
 
-
-
-
-            }
-
-            // und das Ganze nochmal für den vorhergehenden Artikel
-            if($i-1 > -1) {
-                $prev_id = $article_stack[$i-1];   
+                    // und das Ganze nochmal für den vorhergehenden Artikel
+                    if ($i-1 > -1) {
+                        $prev_id = $article_stack[$i-1];
                 
-                  $href_prev = rex_url::backendPage(
-					'content/edit',
-					[
-					'mode' => 'edit',
-					'clang' => $data['clang_id'],
+                        $href_prev = rex_url::backendPage(
+                            'content/edit',
+                            [
+                    'mode' => 'edit',
+                    'clang' => $data['clang_id'],
                     'category_id' => rex_request('category_id'),
-					'article_id' => $prev_id
-				]
-				);
+                    'article_id' => $prev_id
+                ]
+                        );
 
-                if($i < $catcount ) {
+                        if ($i < $catcount) {
+                            $article = rex_article::get($prev_id);
 
-                    $article = rex_article::get($prev_id);
 
-
-                    $predecessor = '
+                            $predecessor = '
 
                         <button class="btn btn-default" disabled>
                            <span class="fa fa-chevron-left"> 
                         </button>
                     ';
 
-                   if ($article){
-                  $predecessor = '
+                            if ($article) {
+                                $predecessor = '
 
                         <a class="btn btn-default" href="'.$href_prev.'">
                            <span class="fa fa-chevron-left"> 
                         </a>
                     ';
-                }
+                            }
+                        }
                     }
-
+                }
+                $i++;
             }
-        }  
-        $i++;
-    }
-}
-$vz = '
+        }
+        $vz = '
 
     '.$predecessor.'
 
     '.$successor.'
-';
-?>   
+'; ?>   
 		<div class="btn-group"><?= $vz ?>
 		<button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
 		<i class="fa fa-clock-o" aria-hidden="true"></i>
@@ -210,11 +192,9 @@ $vz = '
 		<?= $link ?>
 		</ul>
 		</div>
-		<?php }
-        else { ?><ul class="minibar-quickfiles">
+		<?php
+    } else { ?><ul class="minibar-quickfiles">
 		<?= $link ?>
 		</ul>
-<?php } }
-
-
-
+<?php }
+}

--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -87,6 +87,10 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
         // Objekt der aktuellen Kategorie laden
         $cat = rex_category::get(rex_request('category_id'));
 
+        // aktuellen Artikel ermitteln
+        $current_id = rex_request('article_id');
+        $current_article = rex_article::get($current_id);
+
         // alle Artikel aus der aktuellen Kategorie laden
         $article = $cat->getArticles(true);
 
@@ -198,3 +202,4 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
 		</ul>
 <?php }
 }
+

--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -89,7 +89,6 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
 
         // aktuellen Artikel ermitteln
         $current_id = rex_request('article_id');
-        $current_article = rex_article::get($current_id);
 
         // alle Artikel aus der aktuellen Kategorie laden
         $article = $cat->getArticles(true);


### PR DESCRIPTION
<img width="451" alt="Bildschirmfoto 2020-10-11 um 21 38 59" src="https://user-images.githubusercontent.com/791247/95688756-c047bd80-0c0c-11eb-9b44-4b12aa584bbd.png">

<img width="511" alt="Bildschirmfoto 2020-10-11 um 21 59 26" src="https://user-images.githubusercontent.com/791247/95688800-0f8dee00-0c0d-11eb-9928-25fec1457be9.png">


Die Pfeile bleiben bestehen. Werden aber deaktiviert. So ist sichergestellt dass hier nichts zappelt. Sie sitzen immer nach der Kategorie-Auswahl, weil diese mal länger werden kann und sich so die Position verschieben könnte. 

closes: https://github.com/FriendsOfREDAXO/quick_navigation/issues/114
