### PR TITLE
Notice vermeiden

### DIFF
--- a/fragments/quick_articles.php
+++ b/fragments/quick_articles.php
@@ -119,7 +119,7 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
                                     'content/edit',
                                     [
                                         'mode' => 'edit',
-                                        'clang' => $data['clang_id'],
+                                        'clang' => rex_clang::getCurrentId(),
                                         'category_id' => rex_request('category_id'),
                                         'article_id' => $next_id
                                     ]
@@ -140,7 +140,7 @@ if (rex::getUser()->hasPerm('quick_navigation[history]')) {
                                     'content/edit',
                                     [
                                         'mode' => 'edit',
-                                        'clang' => $data['clang_id'],
+                                        'clang' => rex_clang::getCurrentId(),
                                         'category_id' => rex_request('category_id'),
                                         'article_id' => $prev_id
                                     ]


### PR DESCRIPTION
`$data['clang_id']` war in den beiden Zeilen nicht definiert