### PR TITLE
fix: must be an array or an object

### DIFF
--- a/fragments/quick_button.php
+++ b/fragments/quick_button.php
@@ -7,7 +7,7 @@
      <ul class="quicknavi-items quicknavi dropdown-menu dropdown-menu-right">
      <?= (isset($this->link) ? $this->link : '')?>
      <?php 
-    if (isset($this->items) && count($this->items))
+    if (isset($this->items) && is_array($this->items))
         {    
             foreach ($this->items as $item) {
                 echo $item;


### PR DESCRIPTION
...that implements Countable notice bei Neuinstallationen ohne Kategorie und Artikel. (in diesem Fall ist $this->items nämlich weder ein Object noch ein Array)