### PR TITLE
Event quicknavigation:ready auslösen

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ ButtonRegistry::registerButton(new MeinButton(), 5);
 
 To see the default prios, look alt the boot.php
 
+### Quick Navigation Client-Side Event
+
+```js
+$(document).on('quicknavigation:ready', function() { … });
+```
+
+
 ## Author
 
 **Friends Of REDAXO**

--- a/assets/quicknavi.js
+++ b/assets/quicknavi.js
@@ -3,6 +3,8 @@ $(document).on('rex:ready', function() {
     if (root) {
         $.get(root.data('url')).done(function(quickNav) {
             root.html(quickNav);
+            // Event quicknavigation:ready auslösen für Addons, die darauf reagieren möchten.
+            $(document).trigger('quicknavigation:ready');
         });
     }
 });


### PR DESCRIPTION
Um als Addon darauf reagieren zu können, wenn das HTML der Quicknavi im DOM verfügbar ist.